### PR TITLE
Super Mario Odyssey Query Hack

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/MethodReport.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodReport.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
             switch (mode)
             {
                 case ReportMode.Semaphore: ReportSemaphore(state);     break;
-                case ReportMode.Counter:   ReportCounter(state, type); break;
+                //case ReportMode.Counter:   ReportCounter(state, type); break;
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -72,7 +72,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
             state.RegisterCallback(MethodOffset.InvalidateTextures,  InvalidateTextures);
             state.RegisterCallback(MethodOffset.TextureBarrierTiled, TextureBarrierTiled);
 
-            state.RegisterCallback(MethodOffset.ResetCounter, ResetCounter);
+            //state.RegisterCallback(MethodOffset.ResetCounter, ResetCounter);
 
             state.RegisterCallback(MethodOffset.DrawEnd,   DrawEnd);
             state.RegisterCallback(MethodOffset.DrawBegin, DrawBegin);


### PR DESCRIPTION
Disables GL Queries to increase GPU performance on Super Mario Odyssey.
Obviously this is ridiculous, breaks a few games and needs to be
rectified correctly by making the queries run asynchronously somehow.
(eg. only read at fences)